### PR TITLE
coutervalues refactoring, making app working offline

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "@ledgerhq/hw-transport-http": "4.7.3",
     "@ledgerhq/react-native-hid": "4.7.3",
     "@ledgerhq/react-native-hw-transport-ble": "4.7.3",
-    "@ledgerhq/wallet-common": "^1.0.1",
+    "@ledgerhq/wallet-common": "^1.1.0",
     "buffer": "5.1.0",
     "hoist-non-react-statics": "^2.5.0",
     "i18next": "11.1.1",

--- a/src/components/CounterValuePolling.js
+++ b/src/components/CounterValuePolling.js
@@ -1,0 +1,114 @@
+// @flow
+import React from "react";
+import { AppState } from "react-native";
+import hoistNonReactStatic from "hoist-non-react-statics";
+import throttle from "lodash/throttle";
+import { pollRates } from "../actions/counterValues";
+
+// $FlowFixMe
+export const PollingContext = React.createContext(() => {});
+
+export type CounterValuePolling = {
+  poll: () => Promise<*>,
+  polling: boolean
+};
+
+export class CounterValuePollingProvider extends React.Component<
+  {
+    children: *,
+    store: *,
+    pollInitDelay: number,
+    pollThrottle: number,
+    autopollInterval: number
+  },
+  CounterValuePolling
+> {
+  static defaultProps = {
+    pollInitDelay: 1 * 1000,
+    pollThrottle: 10 * 1000,
+    autopollInterval: 120 * 1000
+  };
+
+  poll = throttle(() => {
+    const { store } = this.props;
+    return new Promise((success, failure) => {
+      this.setState(prevState => {
+        if (prevState.polling) return null;
+        store
+          .dispatch(pollRates())
+          .then(() => {
+            if (this.unmounted) return;
+            this.setState({ polling: false }, () => {
+              success();
+            });
+          })
+          .catch(e => {
+            this.setState({ polling: false }, () => {
+              failure(e);
+            });
+          });
+        return { polling: true };
+      });
+    });
+  }, this.props.pollThrottle);
+
+  state = {
+    polling: false,
+    poll: this.poll
+  };
+
+  interval: *;
+  initTimeout: *;
+  unmounted = false;
+
+  componentDidMount() {
+    AppState.addEventListener("change", this.handleAppStateChange);
+    this.initTimeout = setTimeout(this.initPolling, this.props.pollInitDelay);
+  }
+
+  componentWillUnmount() {
+    AppState.removeEventListener("change", this.handleAppStateChange);
+    clearInterval(this.interval);
+    clearTimeout(this.initTimeout);
+    this.unmounted = true;
+  }
+
+  handleAppStateChange = (nextAppState: string) => {
+    if (nextAppState === "active") {
+      this.initPolling();
+    } else {
+      clearInterval(this.interval);
+    }
+  };
+
+  initPolling = () => {
+    clearInterval(this.interval);
+    this.interval = setInterval(this.poll, this.props.autopollInterval);
+    this.poll();
+  };
+
+  render() {
+    return (
+      <PollingContext.Provider value={this.state}>
+        {this.props.children}
+      </PollingContext.Provider>
+    );
+  }
+}
+
+// TODO improve flow types
+export const withCounterValuePolling = (Cmp: *) => {
+  class WithCounterValuePolling extends React.Component<*> {
+    render() {
+      return (
+        <PollingContext.Consumer>
+          {counterValuePolling => (
+            <Cmp counterValuePolling={counterValuePolling} {...this.props} />
+          )}
+        </PollingContext.Consumer>
+      );
+    }
+  }
+  hoistNonReactStatic(WithCounterValuePolling, Cmp);
+  return WithCounterValuePolling;
+};

--- a/src/components/CounterValuePolling.js
+++ b/src/components/CounterValuePolling.js
@@ -1,6 +1,6 @@
 // @flow
 import React from "react";
-import { AppState } from "react-native";
+import { AppState, NetInfo } from "react-native";
 import hoistNonReactStatic from "hoist-non-react-statics";
 import throttle from "lodash/throttle";
 import { pollRates } from "../actions/counterValues";
@@ -9,82 +9,123 @@ import { pollRates } from "../actions/counterValues";
 export const PollingContext = React.createContext(() => {});
 
 export type CounterValuePolling = {
-  poll: () => Promise<*>,
-  polling: boolean
+  poll: () => Promise<boolean>,
+  pending: boolean,
+  error: ?Error
 };
 
 export class CounterValuePollingProvider extends React.Component<
   {
     children: *,
     store: *,
-    pollInitDelay: number,
     pollThrottle: number,
+    pollInitDelay: number,
+    connectionRecoveredDelay: number,
+    activeAppDelay: number,
     autopollInterval: number
   },
   CounterValuePolling
 > {
   static defaultProps = {
-    pollInitDelay: 1 * 1000,
+    // the minimum time between two polls. to prevent spamming the API.
     pollThrottle: 10 * 1000,
+    // the time to wait before the first poll when app starts (allow things to render to not do all at boot time)
+    pollInitDelay: 1 * 1000,
+    // the time to wait before polling after network is back
+    connectionRecoveredDelay: 3 * 1000,
+    // the time to wait before polling after appState is back to active
+    activeAppDelay: 2 * 1000,
+    // the minimum time to wait before two automatic polls (then one that happen whatever network/appstate events)
     autopollInterval: 120 * 1000
   };
 
+  schedulePoll = (ms: number) => {
+    clearTimeout(this.pollTimeout);
+    this.pollTimeout = setTimeout(this.poll, ms);
+  };
+  cancelPoll = () => {
+    clearTimeout(this.pollTimeout);
+  };
+
   poll = throttle(() => {
-    const { store } = this.props;
-    return new Promise((success, failure) => {
+    // we are always scheduling the next poll() (for automatic poll mecanism)
+    // this is not in a setInterval because we don't want poll() to happen too often & always will push the next automatic call as far as possible
+    this.schedulePoll(this.props.autopollInterval);
+
+    return new Promise(success => {
       this.setState(prevState => {
-        if (prevState.polling) return null;
-        store
+        if (prevState.pending) return null; // prevent concurrency calls.
+
+        this.props.store
           .dispatch(pollRates())
+          // TODO pollRates() should have a timeout, because we don't want this promise to hang forever
           .then(() => {
             if (this.unmounted) return;
-            this.setState({ polling: false }, () => {
-              success();
+            this.setState({ pending: false, error: null }, () => {
+              success(true);
             });
           })
-          .catch(e => {
-            this.setState({ polling: false }, () => {
-              failure(e);
+          .catch(error => {
+            if (this.unmounted) return;
+            this.setState({ pending: false, error }, () => {
+              // we don't reject the promise because we handle the error.
+              success(false);
+              // we want to disable next throttle because network problem
+              // this gives opportunity for user to pull straight away.
+              this.poll.cancel();
             });
           });
-        return { polling: true };
+        return { pending: true, error: null };
       });
     });
   }, this.props.pollThrottle);
 
   state = {
-    polling: false,
-    poll: this.poll
+    pending: false,
+    poll: this.poll,
+    error: null
   };
 
-  interval: *;
-  initTimeout: *;
+  pollTimeout: *;
   unmounted = false;
 
   componentDidMount() {
     AppState.addEventListener("change", this.handleAppStateChange);
-    this.initTimeout = setTimeout(this.initPolling, this.props.pollInitDelay);
+    NetInfo.isConnected.addEventListener(
+      "connectionChange",
+      this.handleConnectivityChange
+    );
+    this.schedulePoll(this.props.pollInitDelay);
   }
 
   componentWillUnmount() {
     AppState.removeEventListener("change", this.handleAppStateChange);
-    clearInterval(this.interval);
-    clearTimeout(this.initTimeout);
+    NetInfo.isConnected.removeEventListener(
+      "connectionChange",
+      this.handleConnectivityChange
+    );
+    clearTimeout(this.pollTimeout);
     this.unmounted = true;
   }
 
   handleAppStateChange = (nextAppState: string) => {
+    clearTimeout(this.pollTimeout);
     if (nextAppState === "active") {
-      this.initPolling();
+      // poll when coming back
+      this.schedulePoll(this.props.activeAppDelay);
     } else {
-      clearInterval(this.interval);
+      this.cancelPoll();
     }
   };
 
-  initPolling = () => {
-    clearInterval(this.interval);
-    this.interval = setInterval(this.poll, this.props.autopollInterval);
-    this.poll();
+  // assuming we are connected because we want to start polling when we go connected again
+  wasConnected = true;
+  handleConnectivityChange = (isConnected: boolean) => {
+    if (isConnected && !this.wasConnected) {
+      // poll when recovering a connection
+      this.schedulePoll(this.props.connectionRecoveredDelay);
+    }
+    this.wasConnected = isConnected;
   };
 
   render() {

--- a/src/components/NetworkIndicator.js
+++ b/src/components/NetworkIndicator.js
@@ -15,7 +15,7 @@ class Header extends Component<{
       <View
         style={{
           // TODO proper design
-          backgroundColor: counterValuePolling.error ? "red" : "green",
+          backgroundColor: counterValuePolling.error ? "#f22" : "#6f6",
           width: 8,
           height: 8,
           borderRadius: 8

--- a/src/components/NetworkIndicator.js
+++ b/src/components/NetworkIndicator.js
@@ -1,0 +1,28 @@
+/* @flow */
+import React, { Component } from "react";
+import { View, ActivityIndicator } from "react-native";
+import { withCounterValuePolling } from "./CounterValuePolling";
+import type { CounterValuePolling } from "./CounterValuePolling";
+
+class Header extends Component<{
+  counterValuePolling: CounterValuePolling
+}> {
+  render() {
+    const { counterValuePolling } = this.props;
+    return counterValuePolling.pending ? (
+      <ActivityIndicator color="white" />
+    ) : (
+      <View
+        style={{
+          // TODO proper design
+          backgroundColor: counterValuePolling.error ? "red" : "green",
+          width: 8,
+          height: 8,
+          borderRadius: 8
+        }}
+      />
+    );
+  }
+}
+
+export default withCounterValuePolling(Header);

--- a/src/screens/Dashboard/Header.js
+++ b/src/screens/Dashboard/Header.js
@@ -38,7 +38,7 @@ const styles = StyleSheet.create({
     flex: 1,
     flexDirection: "row",
     paddingLeft: 10,
-    paddingRight: 10
+    paddingRight: 20
   },
   headerLeft: {
     justifyContent: "space-around"

--- a/src/screens/Dashboard/Header.js
+++ b/src/screens/Dashboard/Header.js
@@ -1,20 +1,18 @@
 /* @flow */
 import React, { Component } from "react";
-import { View, StyleSheet, ActivityIndicator } from "react-native";
+import { View, StyleSheet } from "react-native";
 import type { Account } from "@ledgerhq/wallet-common/lib/types";
 import LText from "../../components/LText";
 import { withLocale } from "../../components/LocaleContext";
 import type { TranslateFunction } from "../../components/LocaleContext";
-import { withCounterValuePolling } from "../../components/CounterValuePolling";
-import type { CounterValuePolling } from "../../components/CounterValuePolling";
+import NetworkIndicator from "../../components/NetworkIndicator";
 
 class Header extends Component<{
   accounts: Account[],
-  t: TranslateFunction,
-  counterValuePolling: CounterValuePolling
+  t: TranslateFunction
 }> {
   render() {
-    const { t, accounts, counterValuePolling } = this.props;
+    const { t, accounts } = this.props;
     return (
       <View style={styles.header}>
         <View style={styles.headerLeft}>
@@ -25,15 +23,13 @@ class Header extends Component<{
             {t("home_subtitle", { count: accounts.length })}
           </LText>
         </View>
-        {counterValuePolling.polling ? (
-          <ActivityIndicator style={{ marginRight: 20 }} color="white" />
-        ) : null}
+        <NetworkIndicator />
       </View>
     );
   }
 }
 
-export default withLocale(withCounterValuePolling(Header));
+export default withLocale(Header);
 
 const styles = StyleSheet.create({
   header: {
@@ -41,7 +37,8 @@ const styles = StyleSheet.create({
     justifyContent: "space-between",
     flex: 1,
     flexDirection: "row",
-    paddingLeft: 10
+    paddingLeft: 10,
+    paddingRight: 10
   },
   headerLeft: {
     justifyContent: "space-around"

--- a/src/screens/Dashboard/Header.js
+++ b/src/screens/Dashboard/Header.js
@@ -1,17 +1,20 @@
 /* @flow */
 import React, { Component } from "react";
-import { View, StyleSheet } from "react-native";
+import { View, StyleSheet, ActivityIndicator } from "react-native";
 import type { Account } from "@ledgerhq/wallet-common/lib/types";
 import LText from "../../components/LText";
 import { withLocale } from "../../components/LocaleContext";
 import type { TranslateFunction } from "../../components/LocaleContext";
+import { withCounterValuePolling } from "../../components/CounterValuePolling";
+import type { CounterValuePolling } from "../../components/CounterValuePolling";
 
 class Header extends Component<{
   accounts: Account[],
-  t: TranslateFunction
+  t: TranslateFunction,
+  counterValuePolling: CounterValuePolling
 }> {
   render() {
-    const { t, accounts } = this.props;
+    const { t, accounts, counterValuePolling } = this.props;
     return (
       <View style={styles.header}>
         <View style={styles.headerLeft}>
@@ -22,12 +25,15 @@ class Header extends Component<{
             {t("home_subtitle", { count: accounts.length })}
           </LText>
         </View>
+        {counterValuePolling.polling ? (
+          <ActivityIndicator style={{ marginRight: 20 }} color="white" />
+        ) : null}
       </View>
     );
   }
 }
 
-export default withLocale(Header);
+export default withLocale(withCounterValuePolling(Header));
 
 const styles = StyleSheet.create({
   header: {

--- a/src/screens/Dashboard/index.js
+++ b/src/screens/Dashboard/index.js
@@ -33,6 +33,8 @@ import SectionHeader from "./SectionHeader";
 import NoMoreOperationFooter from "../../components/NoMoreOperationFooter";
 import NoOperationFooter from "../../components/NoOperationFooter";
 import LoadingFooter from "../../components/LoadingFooter";
+import { withCounterValuePolling } from "../../components/CounterValuePolling";
+import type { CounterValuePolling } from "../../components/CounterValuePolling";
 
 const navigationOptions = {
   tabBarIcon: ({ tintColor }: *) => (
@@ -66,6 +68,7 @@ class Dashboard extends Component<
     totalBalancePeriodBegin: number,
     fiatUnit: FiatUnit,
     calculateCounterValue: CalculateCounterValue,
+    counterValuePolling: CounterValuePolling,
     screenProps: {
       topLevelNavigation: *
     }
@@ -88,6 +91,7 @@ class Dashboard extends Component<
     this.setState({ refreshing: true });
     try {
       this.setState({ opCount: 50 });
+      await this.props.counterValuePolling.poll();
     } finally {
       this.setState({ refreshing: false });
     }
@@ -189,7 +193,7 @@ class Dashboard extends Component<
   }
 }
 
-export default connect(mapStateToProps)(Dashboard);
+export default connect(mapStateToProps)(withCounterValuePolling(Dashboard));
 
 const styles = StyleSheet.create({
   topBackground: {

--- a/src/screens/ImportAccounts.js
+++ b/src/screens/ImportAccounts.js
@@ -19,7 +19,7 @@ import LText from "../components/LText";
 import BlueButton from "../components/BlueButton";
 import { getAccounts } from "../reducers/accounts";
 import { updateAccount, addAccount } from "../actions/accounts";
-import { fetchCounterValuesHist } from "../actions/counterValues";
+import { pollRates } from "../actions/counterValues";
 
 type Data = Array<mixed>;
 type AccountData = ["account", string, string, number];
@@ -146,7 +146,7 @@ type Props = {
   accounts: Account[],
   addAccount: Account => void,
   updateAccount: ($Shape<Account>) => void,
-  fetchCounterValuesHist: () => void
+  pollRates: () => void
 };
 type State = {
   selectedAccounts: string[],
@@ -229,12 +229,7 @@ class PresentResult_ extends Component<Props, State> {
 
   onImport = async () => {
     const { selectedAccounts, items } = this.state;
-    const {
-      onDone,
-      addAccount,
-      updateAccount,
-      fetchCounterValuesHist
-    } = this.props;
+    const { onDone, addAccount, updateAccount, pollRates } = this.props;
     this.setState({ importing: true });
     const selectedItems = items.filter(item =>
       selectedAccounts.includes(item.account.id)
@@ -258,7 +253,7 @@ class PresentResult_ extends Component<Props, State> {
         default:
       }
     }
-    await fetchCounterValuesHist();
+    await pollRates();
     // ////////////////////////////////////////////////
 
     onDone();
@@ -393,7 +388,7 @@ class PresentResult_ extends Component<Props, State> {
 const PresentResult = connect(state => ({ accounts: getAccounts(state) }), {
   addAccount,
   updateAccount,
-  fetchCounterValuesHist
+  pollRates
 })(PresentResult_);
 
 class Scanning extends Component<{

--- a/yarn.lock
+++ b/yarn.lock
@@ -461,9 +461,9 @@
     "@ledgerhq/hw-transport" "^4.7.3"
     invariant "^2.2.4"
 
-"@ledgerhq/wallet-common@^1.0.1":
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/@ledgerhq/wallet-common/-/wallet-common-1.0.1.tgz#0e746e5e4fc669404f53db56651e6139c0731ade"
+"@ledgerhq/wallet-common@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@ledgerhq/wallet-common/-/wallet-common-1.1.0.tgz#f57efcce56f86c27269b975906934e6168ab7bfd"
   dependencies:
     "@ledgerhq/currencies" "^4.10.1"
     axios "^0.18.0"


### PR DESCRIPTION
- some bugfixes in wallet-common regarding the countervalue api https://github.com/LedgerHQ/ledger-wallet-common/commit/5e7a064c336175aa0f43e351a4100cd62c0cc83c
- refactor countervalues to adopt unified pollRates() (see draft proposal)
- make app working offline, before it was always waiting countervalues to load..
- add a generic CounterValuePollingProvider & withCounterValuePolling
  - code from Root was migrated in the provider. it have the same autopolling feature / listen to appstate like before. however, it only happens when root is "ready", which is when localstorage is asynchronously read (in the future it is important if we decrypt it)
  - counterValuePolling.poll() method is exposed via context, and returns a Promise (we have used it in the "pull to refresh" of dashboard just for PoC)
  - counterValuePolling.polling is a boolean that is true when a pull is happening, we use it to display a spinner on top right header of dashboard (PoC)

Future improvments:
- we should move counterValues actions / stores logic as much as possible into wallet-common, because all wallet-common dependents will benefit from it, also we eventually will migrate to our next countervalue api
- we need to figure out where we want to poll() & where we want to show to the ui it's polling (to be designed)